### PR TITLE
.env.php file(s) not working

### DIFF
--- a/src/Abodeo/LaravelStripe/LaravelStripeServiceProvider.php
+++ b/src/Abodeo/LaravelStripe/LaravelStripeServiceProvider.php
@@ -32,23 +32,23 @@ class LaravelStripeServiceProvider extends ServiceProvider {
          */
 
 
-	    if (isset($_ENV['stripe.api_key'])) {
-		    $api_key = $_ENV['stripe.api_key'];
-	    } else {
-		    $api_key = isset( $_ENV['stripe']['api_key'] ) ? $_ENV['stripe']['api_key'] : $this->app['config']->get( 'laravel-stripe::stripe.api_key' );
-	    }
+        if (isset($_ENV['stripe.api_key'])) {
+            $api_key = $_ENV['stripe.api_key'];
+        } else {
+            $api_key = isset( $_ENV['stripe']['api_key'] ) ? $_ENV['stripe']['api_key'] : $this->app['config']->get( 'laravel-stripe::stripe.api_key' );
+        }
 
-	    Stripe::setApiKey($api_key);
+        Stripe::setApiKey($api_key);
 
-	    if (isset($_ENV['stripe.publishable_key'])) {
-		    $publishableKey = $_ENV['stripe.publishable_key'];
-	    } else {
-		    $publishableKey = isset($_ENV['stripe']['publishable_key']) ? $_ENV['stripe']['publishable_key'] : $this->app['config']->get('laravel-stripe::stripe.publishable_key');
-	    }
+        if (isset($_ENV['stripe.publishable_key'])) {
+            $publishableKey = $_ENV['stripe.publishable_key'];
+        } else {
+            $publishableKey = isset($_ENV['stripe']['publishable_key']) ? $_ENV['stripe']['publishable_key'] : $this->app['config']->get('laravel-stripe::stripe.publishable_key');
+        }
 
-	    /*
-	    * Register blade compiler for the Stripe publishable key.
-	    */
+        /*
+        * Register blade compiler for the Stripe publishable key.
+        */
         $blade = $this->app['view']->getEngineResolver()->resolve('blade')->getCompiler();
         $blade->extend(function($value, $compiler) use($publishableKey)
             {

--- a/src/Abodeo/LaravelStripe/LaravelStripeServiceProvider.php
+++ b/src/Abodeo/LaravelStripe/LaravelStripeServiceProvider.php
@@ -30,14 +30,25 @@ class LaravelStripeServiceProvider extends ServiceProvider {
          *
          * Read more: http://laravel.com/docs/configuration#environment-configuration
          */
-        $api_key = isset($_ENV['stripe']['api_key']) ? $_ENV['stripe']['api_key'] : $this->app['config']->get('laravel-stripe::stripe.api_key');
-        Stripe::setApiKey($api_key);
 
-        $publishableKey = isset($_ENV['stripe']['publishable_key']) ? $_ENV['stripe']['publishable_key'] : $this->app['config']->get('laravel-stripe::stripe.publishable_key');
 
-        /*
-         * Register blade compiler for the Stripe publishable key.
-         */
+	    if (isset($_ENV['stripe.api_key'])) {
+		    $api_key = $_ENV['stripe.api_key'];
+	    } else {
+		    $api_key = isset( $_ENV['stripe']['api_key'] ) ? $_ENV['stripe']['api_key'] : $this->app['config']->get( 'laravel-stripe::stripe.api_key' );
+	    }
+
+	    Stripe::setApiKey($api_key);
+
+	    if (isset($_ENV['stripe.publishable_key'])) {
+		    $publishableKey = $_ENV['stripe.publishable_key'];
+	    } else {
+		    $publishableKey = isset($_ENV['stripe']['publishable_key']) ? $_ENV['stripe']['publishable_key'] : $this->app['config']->get('laravel-stripe::stripe.publishable_key');
+	    }
+
+	    /*
+	    * Register blade compiler for the Stripe publishable key.
+	    */
         $blade = $this->app['view']->getEngineResolver()->resolve('blade')->getCompiler();
         $blade->extend(function($value, $compiler) use($publishableKey)
             {


### PR DESCRIPTION
Not sure if Laravel 4.2 has changed the way variables saved into $_ENV from the .env files or if it's my dev environment, but the variables in my "dot files" are copied to $_ENV in the format  $_ENV['stripe.api_key'] not $_ENV[ 'stripe']['api_key'].

Even though my .env.php file looks like this:
```
return array(
	'stripe' => array(
		'api_key' => 'sk_test_xxxxxx,
		'publishable_key' => 'pk_test_xxxxx'
	)
);
```

If I dd($_ENV); I can see them:
```
array (size=16)
  ...
  'stripe.api_key' => string 'sk_test_xxxxx' (length=32)
  'stripe.publishable_key' => string 'pk_test_xxxxx' (length=32)
```