### PR TITLE
Updated the way environment configs are referenced to take into account ...

### DIFF
--- a/src/Abodeo/LaravelStripe/LaravelStripeServiceProvider.php
+++ b/src/Abodeo/LaravelStripe/LaravelStripeServiceProvider.php
@@ -30,10 +30,10 @@ class LaravelStripeServiceProvider extends ServiceProvider {
          *
          * Read more: http://laravel.com/docs/configuration#environment-configuration
          */
-        $api_key = isset($_ENV['stripe']['api_key']) ? $_ENV['stripe']['api_key'] : $this->app['config']->get('laravel-stripe::stripe.api_key');
+        $api_key = isset($_ENV['stripe.api_key']) ? $_ENV['stripe.api_key'] : $this->app['config']->get('laravel-stripe::stripe.api_key');
         Stripe::setApiKey($api_key);
 
-        $publishableKey = isset($_ENV['stripe']['publishable_key']) ? $_ENV['stripe']['publishable_key'] : $this->app['config']->get('laravel-stripe::stripe.publishable_key');
+        $publishableKey = isset($_ENV['stripe.publishable_key']) ? $_ENV['stripe.publishable_key'] : $this->app['config']->get('laravel-stripe::stripe.publishable_key');
 
         /*
          * Register blade compiler for the Stripe publishable key.


### PR DESCRIPTION
Environment configuration files (`.env.local.php`, for example) are having their contents referenced incorrectly based on a Laravel 4.2 install.

Currently, Stripe credentials are being referenced like this:

    isset($_ENV['stripe']['publishable_key'])

... in `LaravelStripeServiceProvider.php` when, in fact, they should be referenced like this...

    isset($_ENV['stripe.publishable_key'])

This is due to the fact that Laravel 4.2 will flatten multi-dimensional arrays with a dot concatenation helper.

    if ( ! function_exists('array_dot'))
    {
    	/**
    	 * Flatten a multi-dimensional associative array with dots.
    	 *
    	 * @param  array   $array
    	 * @param  string  $prepend
    	 * @return array
    	 */
    	function array_dot($array, $prepend = '')
    	{
    		return Arr::dot($array, $prepend);
    	}
    }